### PR TITLE
docs: added recipe for Jenkins CI configuration

### DIFF
--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -5,6 +5,7 @@
 - [Travis CI](travis.md)
 - [GitLab CI](gitlab-ci.md)
 - [GitHub Actions](github-actions.md)
+- [Jenkins CI](jenkins-ci.md)
 
 ## Git hosted services
 - [Git authentication with SSH keys](git-auth-ssh-keys.md)

--- a/docs/recipes/jenkins-ci.md
+++ b/docs/recipes/jenkins-ci.md
@@ -1,0 +1,61 @@
+# Using semantic-release with [Jenkins CI](https://www.jenkins.io/doc/book/pipeline/)
+
+## Environment variables
+
+The [Authentication](../usage/ci-configuration.md#authentication) environment variables can be configured in [Jenkins Project Settings](https://www.jenkins.io/doc/pipeline/tour/environment/)..
+
+Alternatively, the default `NPM_TOKEN` and `GH_TOKEN` can be easily [setup with semantic-release-cli](../usage/getting-started.md#getting-started).
+
+## Node.js project configuration
+
+### `Jenkinsfile (Declarative Pipeline)` configuration for a Node.js job
+
+**Note**: The publish pipeline must run a [Node >= 10.18 version](../support/FAQ.md#why-does-semantic-release-require-node-version--1018).
+
+This example is a minimal configuration for **semantic-release** with a build running Node 10.18. See [Jenkins documentation](https://www.jenkins.io/doc/) for additional configuration options.
+
+The`semantic-release` execution command varies depending if you are using a [local](../usage/installation.md#local-installation) or [global](../usage/installation.md#global-installation) **semantic-release** installation.
+
+```yaml
+// The release stage in the pipeline will run only if the test stage in the pipeline is successful
+pipeline {
+    agent any 
+    environment {
+        GH_TOKEN  = credentials('some-id')
+    }
+    stages {
+        stage('Test') {
+            steps {
+                sh '''
+                # Configure your test steps here (checkout, npm install, tests etc)
+                npm install
+                npm test
+                '''
+                }
+        }
+        stage('Release') {
+            tools {
+            nodejs "node 10.18"
+            }
+            steps {
+                sh '''
+                # Run optional required steps before releasing
+                npx semantic-release
+                '''
+            }            
+        }
+    }
+}
+```
+
+### `package.json` configuration for a Node job
+
+A `package.json` is required only for [local](../usage/installation.md#local-installation) **semantic-release** installation.
+
+```json
+{
+  "devDependencies": {
+    "semantic-release": "^15.0.0"
+  }
+}
+```


### PR DESCRIPTION
Have added a new file jenkins-ci.md that contains documentation to configure Semantic release in Jenkins