### PR TITLE
docs(configuration.md): updated documentation for dry-run

### DIFF
--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -116,7 +116,10 @@ Type: `Boolean`<br>
 Default: `false` if running in a CI environment, `true` otherwise<br>
 CLI arguments: `-d`, `--dry-run`
 
-Dry-run mode, skip publishing, print next version and release notes.
+The objective of Dry-run mode is to get preview of the release results before rolling out the final release.
+Dry-run mode, skips the following steps i.e. prepare, publish, success and fail. In addition to this it prints the next version and release notes on the console.
+
+**Note**: The Dry-run mode verifies the repository push permission, even though nothing will be pushed.The verification is done to help user to figure out potential configuartion issues.
 
 ### ci
 


### PR DESCRIPTION
Earlier there were some discrepancies in the doc (_eg. the description of the steps skipped in the process were not apt_). Hence, updated the documentation for dry-run with details and missing info to get a clear picture of what the --dry-run flag actually does. 